### PR TITLE
Implement simple Flask currency converter

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,34 @@
+from flask import Flask, render_template, request
+
+app = Flask(__name__)
+
+@app.route('/', methods=['GET'])
+def index():
+    return render_template('index.html')
+
+@app.route('/convert', methods=['POST'])
+def convert():
+    amount_str = request.form.get('amount', '').strip()
+    direction = request.form.get('direction')
+
+    # Validate amount
+    if not amount_str:
+        return render_template('index.html', error='請輸入金額')
+    try:
+        amount = float(amount_str)
+    except ValueError:
+        return render_template('index.html', error='金額必須為數字')
+
+    # Currency conversion
+    if direction == 'TWD_to_JPY':
+        result = amount * 4.5
+    elif direction == 'JPY_to_TWD':
+        result = amount * 0.222
+    else:
+        return render_template('index.html', error='無效的轉換方向')
+
+    formatted = f"{result:.2f}"
+    return render_template('index.html', result=formatted)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Currency Converter</title>
+</head>
+<body>
+    <h1>Currency Converter</h1>
+    <form action="/convert" method="post">
+        <input type="text" name="amount" placeholder="Amount" value="{{ request.form.amount }}">
+        <select name="direction">
+            <option value="TWD_to_JPY" {% if request.form.direction == 'TWD_to_JPY' %}selected{% endif %}>TWD to JPY</option>
+            <option value="JPY_to_TWD" {% if request.form.direction == 'JPY_to_TWD' %}selected{% endif %}>JPY to TWD</option>
+        </select>
+        <button type="submit">Convert</button>
+    </form>
+
+    {% if error %}
+    <p style="color:red;">{{ error }}</p>
+    {% endif %}
+
+    {% if result %}
+    <p>結果: {{ result }}</p>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Flask backend with `/convert` route
- perform currency conversion based on direction
- validate numeric input and format result
- provide a basic `index.html` to show the result or error

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686cd0b2f0e4832a9f7602bf668b0535